### PR TITLE
`/en`のリダイレクトを追加

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,5 +1,6 @@
 / https://misskey-hub.net/ 308
 /ja-JP/ https://misskey-hub.net/ja/ 308
+/en https://misskey-hub.net/en/ 308
 /en-US/ https://misskey-hub.net/en/ 308
 /de-DE/ https://misskey-hub.net/ 308
 /ko-KR/ https://misskey-hub.net/ko/ 308


### PR DESCRIPTION
`https://join.misskey.page/en`のリンクを貼っている海外のFediverseまとめサイトが複数存在しているため。